### PR TITLE
Add clarification about QoS policy

### DIFF
--- a/pendulum_demo/src/pendulum_controller_standalone.cpp
+++ b/pendulum_demo/src/pendulum_controller_standalone.cpp
@@ -201,7 +201,8 @@ int main(int argc, char * argv[])
   #endif
   rclcpp::executors::SingleThreadedExecutor exec(exec_args);
 
-  // set QoS deadline period
+  // Use rmw_qos_profile_default with history size 10 and set QoS deadline period.
+  // NOTE: rmw_qos_profile_default uses reliable policy by default
   rclcpp::QoS qos_deadline_profile(10);
   qos_deadline_profile.deadline(deadline_duration);
 

--- a/pendulum_demo/src/pendulum_driver_standalone.cpp
+++ b/pendulum_demo/src/pendulum_driver_standalone.cpp
@@ -182,7 +182,8 @@ int main(int argc, char * argv[])
   #endif
   rclcpp::executors::SingleThreadedExecutor exec(exec_args);
 
-  // set QoS deadline period
+  // Use rmw_qos_profile_default with history size 10 and set QoS deadline period.
+  // NOTE: rmw_qos_profile_default uses reliable policy by default
   rclcpp::QoS qos_deadline_profile(10);
   qos_deadline_profile.deadline(deadline_duration);
 


### PR DESCRIPTION
Hello, first of all, thanks for a nice project. This PR is more for discussion.

For context: I'm using this project to test different scenarios on my Jetson AGX Xavier with RT kernel. I'm running only standalone controller on Xavier and everything else on my laptop. I'm running `stress` command that runs many sqrt threads. This allows me to disbalance pendulum. NOTE: when i was running everything on Xavier i was not able to break pendulum even with high CPU stressing.

About this change: I found that with heavy CPU stress, i receive only ~60-80 cmd msg/s instead of 1000. There are many reasons involved, but i found that using "best effort" reliability improves number of messages twice (~150 msg/s). I also see that original [repo](https://github.com/ros2/demos/blob/e1453fc25f0af51abe5aa6d75f5601f4ab69395c/pendulum_control/src/pendulum_demo.cpp#L147-L157) uses best effort and history size 1. Please let me know what you think.

~Commit message:~
~- Use best effort with history size 1 for commands.~
~This improves performance under high system load.~
~Same used in original repo https://github.com/ros2/demos/blob/e1453fc25f0af51abe5aa6d75f5601f4ab69395c/pendulum_control/src/pendulum_demo.cpp#L147-L157~
~- Extend driver options with command_qos_profile~