### PR TITLE
Add timestamp to pendulum state message

### DIFF
--- a/pendulum_driver/pendulum_driver/src/pendulum_driver_node.cpp
+++ b/pendulum_driver/pendulum_driver/src/pendulum_driver_node.cpp
@@ -61,6 +61,7 @@ void PendulumDriverNode::state_timer_callback()
 {
   driver_interface_->update();
   driver_interface_->update_status_data(state_message_);
+  state_message_.header.stamp = this->get_clock()->now();
   state_pub_->publish(state_message_);
 }
 


### PR DESCRIPTION
This MR sets the joint_state header timestamp using the node clock time. This is required to publish /tf messages. 