### PR TITLE
Add topic statistics support

### DIFF
--- a/pendulum_bringup/params/pendulum.param.yaml
+++ b/pendulum_bringup/params/pendulum.param.yaml
@@ -4,6 +4,9 @@ pendulum_controller:
     command_topic_name: "command"
     setpoint_topic_name: "setpoint"
     command_publish_period_us: 10000
+    enable_topic_stats: False
+    topic_stats_topic_name: "controller_stats"
+    topic_stats_publish_period_ms: 1000
     controller:
       feedback_matrix: [-10.0000, -51.5393, 356.8637, 154.4146]
 
@@ -15,6 +18,9 @@ pendulum_driver:
     cart_base_joint_name: "cart_base_joint"
     pole_joint_name: "pole_joint"
     state_publish_period_us: 10000
+    enable_topic_stats: False
+    topic_stats_topic_name: "driver_stats"
+    topic_stats_publish_period_ms: 1000
     driver:
       pendulum_mass: 1.0
       cart_mass: 5.0

--- a/pendulum_controller/include/pendulum_controller/pendulum_controller_node.hpp
+++ b/pendulum_controller/include/pendulum_controller/pendulum_controller_node.hpp
@@ -63,6 +63,9 @@ public:
   /// \param[in] command_topic_name Name of the command topic
   /// \param[in] setpoint_topic_name Name of the setpoint topic
   /// \param[in] command_publish_period Period of the command topic publishing
+  /// \param[in] enable_topic_stats Enable topic statistics publishing
+  /// \param[in] topic_stats_topic_name Name of the stats topic
+  /// \param[in] topic_stats_publish_period Period of the stats topic publishing
   /// \param[in] controller_cfg Configuration class for the controller
   PENDULUM_CONTROLLER_PUBLIC PendulumControllerNode(
     const std::string & node_name,
@@ -70,6 +73,9 @@ public:
     const std::string & command_topic_name,
     const std::string & setpoint_topic_name,
     std::chrono::microseconds command_publish_period,
+    bool enable_topic_stats,
+    const std::string & topic_stats_topic_name,
+    std::chrono::milliseconds topic_stats_publish_period,
     const PendulumController::Config & controller_cfg);
 
   /// \brief Get the sensor subscription's settings options.
@@ -122,6 +128,9 @@ private:
   const std::string command_topic_name_;
   const std::string setpoint_topic_name_;
   std::chrono::microseconds command_publish_period_;
+  bool enable_topic_stats_;
+  const std::string topic_stats_topic_name_;
+  std::chrono::milliseconds topic_stats_publish_period_;
 
   PendulumController controller_;
 

--- a/pendulum_driver/include/pendulum_driver/pendulum_driver_node.hpp
+++ b/pendulum_driver/include/pendulum_driver/pendulum_driver_node.hpp
@@ -69,6 +69,9 @@ public:
     const std::string & cart_base_joint_name,
     const std::string & pole_joint_name,
     std::chrono::microseconds status_publish_period,
+    bool enable_topic_stats,
+    const std::string & topic_stats_topic_name,
+    std::chrono::milliseconds topic_stats_publish_period,
     const PendulumDriver::Config & driver_cfg);
 
   /// \brief Initialize pendulum driver
@@ -126,6 +129,9 @@ private:
   const std::string cart_base_joint_name_;
   const std::string pole_joint_name_;
   std::chrono::microseconds state_publish_period_;
+  bool enable_topic_stats_;
+  const std::string topic_stats_topic_name_;
+  std::chrono::milliseconds topic_stats_publish_period_;
   PendulumDriver driver_;
 
   std::shared_ptr<rclcpp::Subscription<


### PR DESCRIPTION
This MR adds support for topic statistics added in Foxy:
- https://index.ros.org/doc/ros2/Concepts/About-Topic-Statistics
- https://index.ros.org/doc/ros2/Tutorials/Topics/Topic-Statistics-Tutorial/
- https://github.com/ros2/demos/tree/master/topic_statistics_demo

This replaces all the custom code to collect topic statistics in eloquent and dashing branches. 

How to test it:

1. Set the enable_topic_stats for one node (or both) to True in the params yaml.
2. Launch the demo
3. Monitor the stats topics: `ros2 topic echo /controller_stats` or ` ros2 topic echo /driver_stats`
4. Check maximum latency and standard deviation are reasonable using RT settings in a real-time kernel.
