### PR TITLE
Add topic statistics helper plot

### DIFF
--- a/pendulum_analysis/topic_statistics_analysis/topic_statistics_plot.py
+++ b/pendulum_analysis/topic_statistics_analysis/topic_statistics_plot.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright 2020 Carlos San Vicente
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Plot topic statistics metrics')
+    parser.add_argument('filename', metavar='filename')
+    parser.add_argument('-s', '--show', help='Show plots', action='store_true')
+    parser.add_argument('-t', '--topicname', metavar='topicname', default=None)
+    parser.add_argument('-m', '--metric', metavar='metric', default='message_period',
+                        help='message_period or message_age')
+    parser.add_argument('-o', '--outfile',
+                        help='Name of file to write plot output')
+    args = parser.parse_args()
+    filename = args.filename
+    topicname = args.topicname
+    show = args.show
+    metric = args.metric
+    outfile = filename + '_plot'
+    if args.outfile is not None:
+        outfile = args.outfile
+    else:
+        if topicname:
+            outfile = topicname + '_' + metric
+        else:
+            outfile = 'topic_statistics' + '_' + metric
+
+    col_names=["measurement_source_name",
+               "metrics_source",
+               "unit",
+               "window_start_sec",
+               "window_start_nsec",
+               "window_stop_sec",
+               "window_stop_nsec",
+               "data_type1",
+               "average",
+               "data_type2",
+               "minimum",
+               "data_type3",
+               "maximum",
+               "data_type4",
+               "standard_deviation",
+               "data_type5",
+               "sample_count"
+               ]
+
+    df_raw = pd.read_csv(filename, delimiter=',', names=col_names)
+
+    # Convert window timestamps to relative time in seconds
+    starttime = df_raw.loc[:, 'window_stop_sec'].iloc[0] + \
+                df_raw.loc[:, 'window_stop_sec'].iloc[0] / 10E9
+    df_raw['time'] = df_raw['window_stop_sec'].astype(float) + \
+                     df_raw['window_stop_nsec'].astype(float) / 10E9 - starttime
+
+    # Filter topic name and metrics
+    if topicname:
+        df = df_raw.loc[(df_raw.metrics_source == metric)
+                        & (df_raw.measurement_source_name == topicname)]
+    else:
+        df = df_raw.loc[(df_raw.metrics_source == metric)]
+
+    # Get metric units
+    unit = df['unit'].iloc[0]
+
+    # Plot topic statistic metrics
+    plt.figure()
+    ax = plt.gca()
+    df.plot(kind='line', x='time', y='average', ax=ax)
+    df.plot(kind='line', x='time', y='minimum', ax=ax)
+    df.plot(kind='line', x='time', y='maximum', ax=ax)
+
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel(metric + " (" + unit + ")")
+    plt.title(metric + ' vs. time')
+    if show:
+        plt.show()
+    plt.savefig(outfile + '.svg')
+
+
+if __name__ == '__main__':
+    main()

--- a/pendulum_analysis/topic_statistics_analysis/topic_statistics_plot.py
+++ b/pendulum_analysis/topic_statistics_analysis/topic_statistics_plot.py
@@ -37,9 +37,9 @@ def main():
         outfile = args.outfile
     else:
         if topicname:
-            outfile = topicname + '_' + metric
+            outfile = f"{topicname}_{metric}"
         else:
-            outfile = 'topic_statistics' + '_' + metric
+            outfile = f"topic_statistics_{metric}"
 
     col_names=["measurement_source_name",
                "metrics_source",
@@ -86,11 +86,11 @@ def main():
     df.plot(kind='line', x='time', y='maximum', ax=ax)
 
     ax.set_xlabel("Time (s)")
-    ax.set_ylabel(metric + " (" + unit + ")")
-    plt.title(metric + ' vs. time')
+    ax.set_ylabel(f"{metric} ({unit} )")
+    plt.title(f"{metric}  vs. time")
     if show:
         plt.show()
-    plt.savefig(outfile + '.svg')
+    plt.savefig(f"{outfile}.svg")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a script to plot metrics from the topic statistics topic.

- [x] Test script with all the options
 
## Instructions

1. Enable `enable_topic_stats: True` param

2. Launch demo

```bash
 ros2 launch pendulum_bringup pendulum_bringup.launch.py
```
3. Log controller_stats in csv format

```bash
ros2 topic echo /controller_stats --csv > controller_stats.csv
```
4. Run script passing the csv file:

```bash
python3 topic_statistics_plot.py path/to/controller_stats.csv --show -m message_period
```

5. Check plot

![Figure_1](https://user-images.githubusercontent.com/28007363/93713017-9f360480-fb59-11ea-9cdf-f0ef0f593c05.png)

```bash
python3 topic_statistics_plot.py path/to/controller_stats.csv --show -m message_age
```
![Figure_2](https://user-images.githubusercontent.com/28007363/93713019-a230f500-fb59-11ea-872a-01ba3960296e.png)


## Notes

- Apparently the topic statistics maximum and minimum are not calculated for the measurement window but for the whole time. This makes the plot less informative.
- The script assumes the order of the metrics is fixed. This could change in the future. This can be improved by using the data_types information.
- The script will fail if there are NaN.
 

