### PR TITLE
Make controller data driven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,12 @@ ade/.bash_logout
 ade/.bashrc
 ade/.profile
 ade/.ssh
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Jupyter Notebook
+.ipynb_checkpoints

--- a/pendulum_bringup/params/pendulum.param.yaml
+++ b/pendulum_bringup/params/pendulum.param.yaml
@@ -3,7 +3,6 @@ pendulum_controller:
     state_topic_name: "joint_states"
     command_topic_name: "joint_command"
     teleop_topic_name: "teleop"
-    command_publish_period_us: 10000
     enable_topic_stats: False
     topic_stats_topic_name: "controller_stats"
     topic_stats_publish_period_ms: 1000

--- a/pendulum_controller/CMakeLists.txt
+++ b/pendulum_controller/CMakeLists.txt
@@ -57,18 +57,39 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(launch_testing_ament_cmake)
+  add_launch_test(
+      test/pendulum_controller_lifecycle.test.py
+      TARGET pendulum_controller_lifecycle.test
+      ENV
+      TIMEOUT 30
+  )
+  add_launch_test(
+      test/pendulum_controller_autostart.test.py
+      TARGET pendulum_controller_autostart.test
+      ENV
+      TIMEOUT 30
+  )
 endif()
 
 install(
-  DIRECTORY include/
-  DESTINATION include
+    DIRECTORY include/
+    DESTINATION include
 )
 
-install(TARGETS ${PENDULUM_CONTROLLER_LIB} ${PENDULUM_CONTROLLER_EXE}
-        EXPORT export_${PENDULUM_CONTROLLER_LIB}
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION lib/${PROJECT_NAME}
-        INCLUDES DESTINATION include)
+install(
+    DIRECTORY params
+    DESTINATION share/${PROJECT_NAME}
+)
+
+install(
+    TARGETS ${PENDULUM_CONTROLLER_LIB} ${PENDULUM_CONTROLLER_EXE}
+    EXPORT export_${PENDULUM_CONTROLLER_LIB}
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+    INCLUDES DESTINATION include
+)
 
 ament_package()

--- a/pendulum_controller/include/pendulum_controller/pendulum_controller_node.hpp
+++ b/pendulum_controller/include/pendulum_controller/pendulum_controller_node.hpp
@@ -62,9 +62,6 @@ private:
   /// \brief Create command publisher
   void create_command_publisher();
 
-  /// \brief Create command timer callback
-  void create_command_timer_callback();
-
   /// \brief Log pendulum controller state
   void log_controller_state();
 
@@ -96,7 +93,6 @@ private:
   const std::string state_topic_name_;
   const std::string command_topic_name_;
   const std::string teleop_topic_name_;
-  std::chrono::microseconds command_publish_period_;
   bool enable_topic_stats_;
   const std::string topic_stats_topic_name_;
   std::chrono::milliseconds topic_stats_publish_period_;
@@ -110,8 +106,6 @@ private:
       pendulum2_msgs::msg::PendulumTeleop>> teleop_sub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<
       pendulum2_msgs::msg::JointCommandStamped>> command_pub_;
-
-  rclcpp::TimerBase::SharedPtr command_timer_;
   pendulum2_msgs::msg::JointCommandStamped command_message_;
 
   uint32_t num_missed_deadlines_pub_;

--- a/pendulum_controller/package.xml
+++ b/pendulum_controller/package.xml
@@ -28,6 +28,9 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>ros_testing</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/pendulum_controller/params/test.param.yaml
+++ b/pendulum_controller/params/test.param.yaml
@@ -1,0 +1,12 @@
+pendulum_controller:
+  ros__parameters:
+    state_topic_name: "joint_states"
+    command_topic_name: "joint_command"
+    teleop_topic_name: "teleop"
+    command_publish_period_us: 10000
+    enable_topic_stats: False
+    topic_stats_topic_name: "controller_stats"
+    topic_stats_publish_period_ms: 1000
+    deadline_duration_ms: 0
+    controller:
+      feedback_matrix: [-10.0000, -51.5393, 356.8637, 154.4146]

--- a/pendulum_controller/params/test.param.yaml
+++ b/pendulum_controller/params/test.param.yaml
@@ -3,7 +3,6 @@ pendulum_controller:
     state_topic_name: "joint_states"
     command_topic_name: "joint_command"
     teleop_topic_name: "teleop"
-    command_publish_period_us: 10000
     enable_topic_stats: False
     topic_stats_topic_name: "controller_stats"
     topic_stats_publish_period_ms: 1000

--- a/pendulum_controller/test/pendulum_controller_autostart.test.py
+++ b/pendulum_controller/test/pendulum_controller_autostart.test.py
@@ -1,0 +1,89 @@
+# Copyright 2020 Carlos San Vicente
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import signal
+
+import unittest
+
+import launch
+import launch_ros.actions
+import launch_ros.events
+import launch_ros.events.lifecycle
+
+from launch_ros.substitutions import FindPackageShare
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.util
+
+import pytest
+
+
+@pytest.mark.rostest
+def generate_test_description():
+    package_dir = FindPackageShare('pendulum_controller').find('pendulum_controller')
+    param_file_path = os.path.join(package_dir, 'params', 'test.param.yaml')
+    param_file = launch.substitutions.LaunchConfiguration('params', default=[param_file_path])
+
+    controller_node = launch_ros.actions.LifecycleNode(
+        package='pendulum_controller',
+        executable='pendulum_controller_exe',
+        name='pendulum_controller',
+        parameters=[param_file],
+        arguments=['--autostart', 'True'],
+        additional_env={'PYTHONUNBUFFERED': '1'}
+    )
+
+    shutdown_timer = launch.actions.TimerAction(
+        period=5.0,
+        actions=[
+            launch.actions.EmitEvent(
+                event=launch.events.process.SignalProcess(
+                    signal_number=signal.SIGINT,
+                    process_matcher=lambda proc: proc is controller_node
+                )
+            )
+        ]
+    )
+
+    return (
+        launch.LaunchDescription([
+            controller_node,
+            shutdown_timer,
+            launch_testing.util.KeepAliveProc(),
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {
+            'controller_node': controller_node,
+        }
+    )
+
+
+class TestControllerNode(unittest.TestCase):
+
+    def test_proc_starts(self, proc_info, controller_node):
+        proc_info.assertWaitForStartup(process=controller_node, timeout=5)
+
+    def test_proc_terminates(self, proc_info, controller_node):
+        proc_info.assertWaitForShutdown(controller_node, timeout=10)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_node_graceful_shutdown(self, proc_info, controller_node):
+        """Test controller_node graceful shutdown."""
+        launch_testing.asserts.assertExitCodes(proc_info, process=controller_node)

--- a/pendulum_controller/test/pendulum_controller_lifecycle.test.py
+++ b/pendulum_controller/test/pendulum_controller_lifecycle.test.py
@@ -1,0 +1,176 @@
+# Copyright 2020 Carlos San Vicente
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+
+import unittest
+
+import launch
+import launch.event_handlers.on_process_start
+
+import launch_ros.actions
+import launch_ros.events
+import launch_ros.events.lifecycle
+from launch_ros.substitutions import FindPackageShare
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.util
+
+import lifecycle_msgs.msg
+
+import pytest
+
+
+@pytest.mark.rostest
+def generate_test_description():
+    package_dir = FindPackageShare('pendulum_controller').find('pendulum_controller')
+    param_file_path = os.path.join(package_dir, 'params', 'test.param.yaml')
+    param_file = launch.substitutions.LaunchConfiguration('params', default=[param_file_path])
+
+    controller_node = launch_ros.actions.LifecycleNode(
+        package='pendulum_controller',
+        executable='pendulum_controller_exe',
+        name='pendulum_controller',
+        parameters=[param_file],
+        arguments=['--autostart', 'False'],
+        additional_env={'PYTHONUNBUFFERED': '1'},
+        namespace=''
+    )
+
+    # Right after the talker starts, make it take the 'configure' transition.
+    event_configure = launch.actions.RegisterEventHandler(
+        launch.event_handlers.on_process_start.OnProcessStart(
+            target_action=controller_node,
+            on_start=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(controller_node),
+                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
+                )),
+            ],
+        )
+    )
+
+    # When the node reaches the 'inactive' state, make it take the 'activate' transition.
+    event_activate = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=controller_node,
+            start_state='configuring', goal_state='inactive',
+            entities=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(controller_node),
+                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE,
+                )),
+            ],
+        )
+    )
+    # When the node reaches the 'active' state, wait a bit and then make it take the
+    # 'deactivate' transition.
+    event_deactivate = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=controller_node, start_state='activating', goal_state='active',
+            entities=[
+                launch.actions.TimerAction(period=1.0, actions=[
+                    launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                        lifecycle_node_matcher=launch.events.matches_action(controller_node),
+                        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_DEACTIVATE,
+                    )),
+                ]),
+            ],
+        )
+    )
+    # When the node reaches the 'inactive' state coming from the 'active' state,
+    # make it take the 'cleanup' transition.
+    event_clean = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=controller_node,
+            start_state='deactivating', goal_state='inactive',
+            entities=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(controller_node),
+                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CLEANUP,
+                )),
+            ],
+        )
+    )
+    # When the node reaches the 'unconfigured' state after a 'cleanup' transition,
+    # make it take the 'unconfigured_shutdown' transition.
+    event_shutdown = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=controller_node,
+            start_state='cleaningup', goal_state='unconfigured',
+            entities=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(controller_node),
+                    transition_id=(
+                        lifecycle_msgs.msg.Transition.TRANSITION_UNCONFIGURED_SHUTDOWN
+                    ),
+                )),
+            ],
+        )
+    )
+
+    return (
+        launch.LaunchDescription([
+            controller_node,
+            event_configure,
+            event_activate,
+            event_deactivate,
+            event_clean,
+            event_shutdown,
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {
+            'controller_node': controller_node,
+        }
+    )
+
+
+class TestcontrollerNode(unittest.TestCase):
+
+    def test_proc_starts(self, proc_info, controller_node):
+        proc_info.assertWaitForStartup(process=controller_node, timeout=5)
+
+
+class TestLifecycle(unittest.TestCase):
+
+    def test_controller_lifecycle(self, proc_output, controller_node):
+        """Test pendulum_controller lifecycle."""
+        proc_output.assertWaitFor('Configuring', process=controller_node, timeout=5)
+        proc_output.assertWaitFor('Activating', process=controller_node, timeout=5)
+        proc_output.assertWaitFor('Deactivating', process=controller_node, timeout=10)
+        pattern = re.compile(r'Cart position = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=controller_node, timeout=5)
+        pattern = re.compile(r'Cart velocity = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=controller_node, timeout=5)
+        pattern = re.compile(r'Pole angular velocity = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=controller_node, timeout=5)
+        pattern = re.compile(r'Teleoperation cart position = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=controller_node, timeout=5)
+        pattern = re.compile(r'Teleoperation cart velocity = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=controller_node, timeout=5)
+        pattern = re.compile(r'Force command = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=controller_node, timeout=5)
+        proc_output.assertWaitFor('Cleaning up', process=controller_node, timeout=5)
+        proc_output.assertWaitFor('Shutting down', process=controller_node, timeout=5)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_node_graceful_shutdown(self, proc_info, controller_node):
+        """Test controller_node graceful shutdown."""
+        launch_testing.asserts.assertExitCodes(proc_info, process=controller_node)

--- a/pendulum_demo/CMakeLists.txt
+++ b/pendulum_demo/CMakeLists.txt
@@ -26,7 +26,26 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(launch_testing_ament_cmake)
+  add_launch_test(
+      test/pendulum_demo_autostart.test.py
+      TARGET pendulum_demo_autostart.test
+      ENV
+      TIMEOUT 30
+  )
+  add_launch_test(
+      test/pendulum_demo_lifecycle.test.py
+      TARGET pendulum_demo_lifecycle.test
+      ENV
+      TIMEOUT 30
+  )
 endif()
+
+install(
+    DIRECTORY params
+    DESTINATION share/${PROJECT_NAME}
+)
 
 install(TARGETS ${PENDULUM_DEMO_EXE}
     LIBRARY DESTINATION lib

--- a/pendulum_demo/package.xml
+++ b/pendulum_demo/package.xml
@@ -20,6 +20,9 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>ros_testing</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/pendulum_demo/params/test.param.yaml
+++ b/pendulum_demo/params/test.param.yaml
@@ -1,0 +1,33 @@
+pendulum_controller:
+  ros__parameters:
+    state_topic_name: "joint_states"
+    command_topic_name: "joint_command"
+    teleop_topic_name: "teleop"
+    command_publish_period_us: 10000
+    enable_topic_stats: False
+    topic_stats_topic_name: "controller_stats"
+    topic_stats_publish_period_ms: 1000
+    deadline_duration_ms: 0
+    controller:
+      feedback_matrix: [-10.0000, -51.5393, 356.8637, 154.4146]
+
+pendulum_driver:
+  ros__parameters:
+    state_topic_name: "joint_states"
+    command_topic_name: "joint_command"
+    disturbance_topic_name: "disturbance"
+    cart_base_joint_name: "cart_base_joint"
+    pole_joint_name: "pole_joint"
+    state_publish_period_us: 10000
+    enable_topic_stats: False
+    topic_stats_topic_name: "driver_stats"
+    topic_stats_publish_period_ms: 1000
+    deadline_duration_ms: 0
+    driver:
+      pendulum_mass: 1.0
+      cart_mass: 5.0
+      pendulum_length: 2.0
+      damping_coefficient: 20.0
+      gravity: -9.8
+      max_cart_force: 1000.0
+      noise_level: 0.0

--- a/pendulum_demo/params/test.param.yaml
+++ b/pendulum_demo/params/test.param.yaml
@@ -3,7 +3,6 @@ pendulum_controller:
     state_topic_name: "joint_states"
     command_topic_name: "joint_command"
     teleop_topic_name: "teleop"
-    command_publish_period_us: 10000
     enable_topic_stats: False
     topic_stats_topic_name: "controller_stats"
     topic_stats_publish_period_ms: 1000

--- a/pendulum_demo/test/pendulum_demo_autostart.test.py
+++ b/pendulum_demo/test/pendulum_demo_autostart.test.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Carlos San Vicente
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import signal
+
+import unittest
+
+import launch
+import launch_ros.actions
+import launch_ros.events
+import launch_ros.events.lifecycle
+
+from launch_ros.substitutions import FindPackageShare
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.util
+
+import pytest
+
+
+@pytest.mark.rostest
+def generate_test_description():
+    package_dir = FindPackageShare('pendulum_demo').find('pendulum_demo')
+    param_file_path = os.path.join(package_dir, 'params', 'test.param.yaml')
+    param_file = launch.substitutions.LaunchConfiguration('params', default=[param_file_path])
+
+    pendulum_demo = launch_ros.actions.Node(
+        package='pendulum_demo',
+        executable='pendulum_demo',
+        output='screen',
+        parameters=[param_file],
+        arguments=['--autostart', 'True'],
+    )
+
+    shutdown_timer = launch.actions.TimerAction(
+        period=2.0,
+        actions=[
+            launch.actions.EmitEvent(
+                event=launch.events.process.SignalProcess(
+                    signal_number=signal.SIGINT,
+                    process_matcher=lambda proc: proc is pendulum_demo
+                )
+            )
+        ]
+    )
+
+    return (
+        launch.LaunchDescription([
+            pendulum_demo,
+            shutdown_timer,
+            launch_testing.util.KeepAliveProc(),
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {
+            'pendulum_demo': pendulum_demo,
+        }
+    )
+
+
+class TestPendulumDemo(unittest.TestCase):
+
+    def test_proc_starts(self, proc_info, pendulum_demo):
+        proc_info.assertWaitForStartup(process=pendulum_demo, timeout=5)
+
+    def test_proc_terminates(self, proc_info, pendulum_demo):
+        proc_info.assertWaitForShutdown(pendulum_demo, timeout=10)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_node_graceful_shutdown(self, proc_info, pendulum_demo):
+        """Test pendulum_demo graceful shutdown."""
+        launch_testing.asserts.assertExitCodes(proc_info, process=pendulum_demo)

--- a/pendulum_demo/test/pendulum_demo_lifecycle.test.py
+++ b/pendulum_demo/test/pendulum_demo_lifecycle.test.py
@@ -1,0 +1,214 @@
+# Copyright 2020 Carlos San Vicente
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+
+import unittest
+
+import launch
+import launch.event_handlers.on_process_start
+
+import launch_ros.actions
+import launch_ros.events
+import launch_ros.events.lifecycle
+from launch_ros.substitutions import FindPackageShare
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.util
+
+import lifecycle_msgs.msg
+import pendulum2_msgs.msg
+
+import pytest
+import rclpy
+
+
+def create_lifecycle_events(node):
+    event_configure = launch.actions.RegisterEventHandler(
+        launch.event_handlers.on_process_start.OnProcessStart(
+            target_action=node,
+            on_start=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(node),
+                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
+                )),
+            ],
+        )
+    )
+    event_activate = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=node,
+            start_state='configuring', goal_state='inactive',
+            entities=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(node),
+                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE,
+                )),
+            ],
+        )
+    )
+    event_deactivate = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=node, start_state='activating', goal_state='active',
+            entities=[
+                launch.actions.TimerAction(period=2.0, actions=[
+                    launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                        lifecycle_node_matcher=launch.events.matches_action(node),
+                        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_DEACTIVATE,
+                    )),
+                ]),
+            ],
+        )
+    )
+    event_clean = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=node,
+            start_state='deactivating', goal_state='inactive',
+            entities=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(node),
+                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CLEANUP,
+                )),
+            ],
+        )
+    )
+    event_shutdown = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=node,
+            start_state='cleaningup', goal_state='unconfigured',
+            entities=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(node),
+                    transition_id=(
+                        lifecycle_msgs.msg.Transition.TRANSITION_UNCONFIGURED_SHUTDOWN
+                    ),
+                )),
+            ],
+        )
+    )
+    return ([event_configure,
+             event_activate,
+             event_deactivate,
+             event_clean,
+             event_shutdown])
+
+
+@pytest.mark.rostest
+def generate_test_description():
+    package_dir = FindPackageShare('pendulum_demo').find('pendulum_demo')
+    param_file_path = os.path.join(package_dir, 'params', 'test.param.yaml')
+    param_file = launch.substitutions.LaunchConfiguration('params', default=[param_file_path])
+
+    driver_node = launch_ros.actions.LifecycleNode(
+        package='pendulum_driver',
+        executable='pendulum_driver_exe',
+        name='pendulum_driver',
+        parameters=[param_file],
+        arguments=['--autostart', 'False'],
+        additional_env={'PYTHONUNBUFFERED': '1'},
+        namespace=''
+    )
+
+    controller_node = launch_ros.actions.LifecycleNode(
+        package='pendulum_controller',
+        executable='pendulum_controller_exe',
+        name='pendulum_controller',
+        parameters=[param_file],
+        arguments=['--autostart', 'False'],
+        additional_env={'PYTHONUNBUFFERED': '1'},
+        namespace=''
+    )
+
+    ld = launch.LaunchDescription()
+    ld.add_action(controller_node)
+    ld.add_action(driver_node)
+    for ev in create_lifecycle_events(controller_node):
+        ld.add_action(ev)
+    for ev in create_lifecycle_events(driver_node):
+        ld.add_action(ev)
+    ld.add_action(launch_testing.actions.ReadyToTest())
+    return (ld,
+            {
+                'driver_node': driver_node,
+                'controller_node': controller_node,
+            })
+
+
+class TestDriverNode(unittest.TestCase):
+
+    def test_proc_starts(self, proc_info, driver_node, controller_node):
+        proc_info.assertWaitForStartup(process=driver_node, timeout=5)
+        proc_info.assertWaitForStartup(process=controller_node, timeout=5)
+
+
+class TestLifecycle(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('teleop_node')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_controller_node_transmits(self, controller_node, driver_node, proc_output):
+        pub = self.node.create_publisher(pendulum2_msgs.msg.PendulumTeleop, 'teleop', 10)
+
+        # Wait until both nodes are activated
+        proc_output.assertWaitFor('Configuring', process=driver_node, timeout=5)
+        proc_output.assertWaitFor('Configuring', process=controller_node, timeout=5)
+        proc_output.assertWaitFor('Activating', process=driver_node, timeout=5)
+        proc_output.assertWaitFor('Activating', process=controller_node, timeout=5)
+
+        # Send teleoperation command to move the cart
+        msg = pendulum2_msgs.msg.PendulumTeleop()
+        msg.cart_position = 10.0
+        pub.publish(msg)
+
+        proc_output.assertWaitFor('Deactivating', process=driver_node, timeout=5)
+        pattern = re.compile(r'Cart position = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        pattern = re.compile(r'Cart velocity = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        # Expect pole angle between 2.7 and 3.6 radians
+        pattern = re.compile(r'Pole angle = (2\.[7-9](\d+)?)|(3\.[0-6](\d+)?)')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        pattern = re.compile(r'Pole angular velocity = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        pattern = re.compile(r'Controller force command = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        pattern = re.compile(r'Disturbance force = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        proc_output.assertWaitFor('Cleaning up', process=driver_node, timeout=5)
+        proc_output.assertWaitFor('Shutting down', process=driver_node, timeout=5)
+
+        self.node.destroy_publisher(pub)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_node_graceful_shutdown(self, proc_info, driver_node, controller_node):
+        """Test controller_node graceful shutdown."""
+        launch_testing.asserts.assertExitCodes(proc_info, process=driver_node)
+        launch_testing.asserts.assertExitCodes(proc_info, process=controller_node)

--- a/pendulum_driver/CMakeLists.txt
+++ b/pendulum_driver/CMakeLists.txt
@@ -59,11 +59,30 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(launch_testing_ament_cmake)
+  add_launch_test(
+      test/pendulum_driver_lifecycle.test.py
+      TARGET pendulum_driver_lifecycle.test
+      ENV
+      TIMEOUT 30
+  )
+  add_launch_test(
+      test/pendulum_driver_autostart.test.py
+      TARGET pendulum_driver_autostart.test
+      ENV
+      TIMEOUT 30
+  )
 endif()
 
 install(
     DIRECTORY include/
     DESTINATION include
+)
+
+install(
+    DIRECTORY params
+    DESTINATION share/${PROJECT_NAME}
 )
 
 install(TARGETS ${PENDULUM_DRIVER_LIB} ${PENDULUM_DRIVER_EXE}

--- a/pendulum_driver/package.xml
+++ b/pendulum_driver/package.xml
@@ -21,6 +21,9 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>ros_testing</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/pendulum_driver/params/test.param.yaml
+++ b/pendulum_driver/params/test.param.yaml
@@ -1,0 +1,20 @@
+pendulum_driver:
+  ros__parameters:
+    state_topic_name: "joint_states"
+    command_topic_name: "joint_command"
+    disturbance_topic_name: "disturbance"
+    cart_base_joint_name: "cart_base_joint"
+    pole_joint_name: "pole_joint"
+    state_publish_period_us: 10000
+    enable_topic_stats: False
+    topic_stats_topic_name: "driver_stats"
+    topic_stats_publish_period_ms: 1000
+    deadline_duration_ms: 0
+    driver:
+      pendulum_mass: 1.0
+      cart_mass: 5.0
+      pendulum_length: 2.0
+      damping_coefficient: 20.0
+      gravity: -9.8
+      max_cart_force: 1000.0
+      noise_level: 1.0

--- a/pendulum_driver/src/pendulum_driver_node_main.cpp
+++ b/pendulum_driver/src/pendulum_driver_node_main.cpp
@@ -59,11 +59,11 @@ int main(int argc, char * argv[])
     exec.spin();
     rclcpp::shutdown();
   } catch (const std::exception & e) {
-    RCLCPP_INFO(rclcpp::get_logger("pendulum_demo"), e.what());
+    RCLCPP_INFO(rclcpp::get_logger("pendulum_driver"), e.what());
     ret = 2;
   } catch (...) {
     RCLCPP_INFO(
-      rclcpp::get_logger("pendulum_demo"), "Unknown exception caught. "
+      rclcpp::get_logger("pendulum_driver"), "Unknown exception caught. "
       "Exiting...");
     ret = -1;
   }

--- a/pendulum_driver/test/pendulum_driver_autostart.test.py
+++ b/pendulum_driver/test/pendulum_driver_autostart.test.py
@@ -1,0 +1,89 @@
+# Copyright 2020 Carlos San Vicente
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import signal
+
+import unittest
+
+import launch
+import launch_ros.actions
+import launch_ros.events
+import launch_ros.events.lifecycle
+
+from launch_ros.substitutions import FindPackageShare
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.util
+
+import pytest
+
+
+@pytest.mark.rostest
+def generate_test_description():
+    package_dir = FindPackageShare('pendulum_driver').find('pendulum_driver')
+    param_file_path = os.path.join(package_dir, 'params', 'test.param.yaml')
+    param_file = launch.substitutions.LaunchConfiguration('params', default=[param_file_path])
+
+    driver_node = launch_ros.actions.LifecycleNode(
+        package='pendulum_driver',
+        executable='pendulum_driver_exe',
+        name='pendulum_driver',
+        parameters=[param_file],
+        arguments=['--autostart', 'True'],
+        additional_env={'PYTHONUNBUFFERED': '1'}
+    )
+
+    shutdown_timer = launch.actions.TimerAction(
+        period=1.0,
+        actions=[
+            launch.actions.EmitEvent(
+                event=launch.events.process.SignalProcess(
+                    signal_number=signal.SIGINT,
+                    process_matcher=lambda proc: proc is driver_node
+                )
+            )
+        ]
+    )
+
+    return (
+        launch.LaunchDescription([
+            driver_node,
+            shutdown_timer,
+            launch_testing.util.KeepAliveProc(),
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {
+            'driver_node': driver_node,
+        }
+    )
+
+
+class TestDriverNode(unittest.TestCase):
+
+    def test_proc_starts(self, proc_info, driver_node):
+        proc_info.assertWaitForStartup(process=driver_node, timeout=5)
+
+    def test_proc_terminates(self, proc_info, driver_node):
+        proc_info.assertWaitForShutdown(driver_node, timeout=10)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_node_graceful_shutdown(self, proc_info, driver_node):
+        """Test controller_node graceful shutdown."""
+        launch_testing.asserts.assertExitCodes(proc_info, process=driver_node)

--- a/pendulum_driver/test/pendulum_driver_lifecycle.test.py
+++ b/pendulum_driver/test/pendulum_driver_lifecycle.test.py
@@ -1,0 +1,174 @@
+# Copyright 2020 Carlos San Vicente
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+
+import unittest
+
+import launch
+import launch.event_handlers.on_process_start
+
+import launch_ros.actions
+import launch_ros.events
+import launch_ros.events.lifecycle
+from launch_ros.substitutions import FindPackageShare
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.util
+
+import lifecycle_msgs.msg
+
+import pytest
+
+
+@pytest.mark.rostest
+def generate_test_description():
+    package_dir = FindPackageShare('pendulum_driver').find('pendulum_driver')
+    param_file_path = os.path.join(package_dir, 'params', 'test.param.yaml')
+    param_file = launch.substitutions.LaunchConfiguration('params', default=[param_file_path])
+
+    driver_node = launch_ros.actions.LifecycleNode(
+        package='pendulum_driver',
+        executable='pendulum_driver_exe',
+        name='pendulum_driver',
+        parameters=[param_file],
+        arguments=['--autostart', 'False'],
+        additional_env={'PYTHONUNBUFFERED': '1'},
+        namespace=''
+    )
+
+    # Right after the talker starts, make it take the 'configure' transition.
+    event_configure = launch.actions.RegisterEventHandler(
+        launch.event_handlers.on_process_start.OnProcessStart(
+            target_action=driver_node,
+            on_start=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(driver_node),
+                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
+                )),
+            ],
+        )
+    )
+
+    # When the node reaches the 'inactive' state, make it take the 'activate' transition.
+    event_activate = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=driver_node,
+            start_state='configuring', goal_state='inactive',
+            entities=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(driver_node),
+                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE,
+                )),
+            ],
+        )
+    )
+    # When the node reaches the 'active' state, wait a bit and then make it take the
+    # 'deactivate' transition.
+    event_deactivate = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=driver_node, start_state='activating', goal_state='active',
+            entities=[
+                launch.actions.TimerAction(period=1.0, actions=[
+                    launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                        lifecycle_node_matcher=launch.events.matches_action(driver_node),
+                        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_DEACTIVATE,
+                    )),
+                ]),
+            ],
+        )
+    )
+    # When the node reaches the 'inactive' state coming from the 'active' state,
+    # make it take the 'cleanup' transition.
+    event_clean = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=driver_node,
+            start_state='deactivating', goal_state='inactive',
+            entities=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(driver_node),
+                    transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CLEANUP,
+                )),
+            ],
+        )
+    )
+    # When the node reaches the 'unconfigured' state after a 'cleanup' transition,
+    # make it take the 'unconfigured_shutdown' transition.
+    event_shutdown = launch.actions.RegisterEventHandler(
+        launch_ros.event_handlers.OnStateTransition(
+            target_lifecycle_node=driver_node,
+            start_state='cleaningup', goal_state='unconfigured',
+            entities=[
+                launch.actions.EmitEvent(event=launch_ros.events.lifecycle.ChangeState(
+                    lifecycle_node_matcher=launch.events.matches_action(driver_node),
+                    transition_id=(
+                        lifecycle_msgs.msg.Transition.TRANSITION_UNCONFIGURED_SHUTDOWN
+                    ),
+                )),
+            ],
+        )
+    )
+
+    return (
+        launch.LaunchDescription([
+            driver_node,
+            event_configure,
+            event_activate,
+            event_deactivate,
+            event_clean,
+            event_shutdown,
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {
+            'driver_node': driver_node,
+        }
+    )
+
+
+class TestDriverNode(unittest.TestCase):
+
+    def test_proc_starts(self, proc_info, driver_node):
+        proc_info.assertWaitForStartup(process=driver_node, timeout=5)
+
+
+class TestLifecycle(unittest.TestCase):
+
+    def test_driver_lifecycle(self, proc_output, driver_node):
+        """Test pendulum_driver lifecycle."""
+        proc_output.assertWaitFor('Configuring', process=driver_node, timeout=5)
+        proc_output.assertWaitFor('Activating', process=driver_node, timeout=5)
+        proc_output.assertWaitFor('Deactivating', process=driver_node, timeout=10)
+        pattern = re.compile(r'Cart position = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        pattern = re.compile(r'Cart velocity = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        pattern = re.compile(r'Pole angular velocity = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        pattern = re.compile(r'Controller force command = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        pattern = re.compile(r'Disturbance force = [+-]?\d+(?:\.\d+)?')
+        proc_output.assertWaitFor(expected_output=pattern, process=driver_node, timeout=5)
+        proc_output.assertWaitFor('Cleaning up', process=driver_node, timeout=5)
+        proc_output.assertWaitFor('Shutting down', process=driver_node, timeout=5)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_node_graceful_shutdown(self, proc_info, driver_node):
+        """Test controller_node graceful shutdown."""
+        launch_testing.asserts.assertExitCodes(proc_info, process=driver_node)


### PR DESCRIPTION
This PR makes the pendulum_controller to follow a data driven approach instead of a timer driven one. This will simplify the timing configuration since the controller will be updated at the rate specified in the pendulum_driver.

Requires https://github.com/ros2-realtime-demo/pendulum/pull/50

