### PR TITLE
Use bounded msgs

### DIFF
--- a/pendulum2_msgs/CMakeLists.txt
+++ b/pendulum2_msgs/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(std_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
+    "msg/JointState.msg"
     "msg/JointCommand.msg"
     "msg/JointCommandStamped.msg"
     "msg/PendulumTeleop.msg"

--- a/pendulum2_msgs/msg/.idea/modules.xml
+++ b/pendulum2_msgs/msg/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/msg.iml" filepath="$PROJECT_DIR$/.idea/msg.iml" />
+    </modules>
+  </component>
+</project>

--- a/pendulum2_msgs/msg/.idea/modules.xml
+++ b/pendulum2_msgs/msg/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/msg.iml" filepath="$PROJECT_DIR$/.idea/msg.iml" />
-    </modules>
-  </component>
-</project>

--- a/pendulum2_msgs/msg/.idea/vcs.xml
+++ b/pendulum2_msgs/msg/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
-  </component>
-</project>

--- a/pendulum2_msgs/msg/.idea/vcs.xml
+++ b/pendulum2_msgs/msg/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/pendulum2_msgs/msg/JointState.msg
+++ b/pendulum2_msgs/msg/JointState.msg
@@ -1,0 +1,5 @@
+float64 pole_angle
+float64 pole_velocity
+float64 cart_position
+float64 cart_velocity
+float64 cart_force

--- a/pendulum_bringup/launch/pendulum_bringup.launch.py
+++ b/pendulum_bringup/launch/pendulum_bringup.launch.py
@@ -103,6 +103,12 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration('rviz'))
     )
 
+    pendulum_state_publisher_runner = Node(
+        package='pendulum_state_publisher',
+        executable='pendulum_state_publisher',
+        condition=IfCondition(LaunchConfiguration('rviz'))
+    )
+
     ld = LaunchDescription()
 
     ld.add_action(autostart_param)
@@ -115,5 +121,6 @@ def generate_launch_description():
     ld.add_action(robot_state_publisher_runner)
     ld.add_action(pendulum_demo_runner)
     ld.add_action(rviz_runner)
+    ld.add_action(pendulum_state_publisher_runner)
 
     return ld

--- a/pendulum_bringup/params/pendulum.param.yaml
+++ b/pendulum_bringup/params/pendulum.param.yaml
@@ -1,6 +1,6 @@
 pendulum_controller:
   ros__parameters:
-    state_topic_name: "joint_states"
+    state_topic_name: "pendulum_joint_states"
     command_topic_name: "joint_command"
     teleop_topic_name: "teleop"
     enable_topic_stats: False
@@ -12,7 +12,7 @@ pendulum_controller:
 
 pendulum_driver:
   ros__parameters:
-    state_topic_name: "joint_states"
+    state_topic_name: "pendulum_joint_states"
     command_topic_name: "joint_command"
     disturbance_topic_name: "disturbance"
     cart_base_joint_name: "cart_base_joint"

--- a/pendulum_controller/include/pendulum_controller/pendulum_controller.hpp
+++ b/pendulum_controller/include/pendulum_controller/pendulum_controller.hpp
@@ -21,8 +21,7 @@
 #include <cmath>
 #include <vector>
 
-#include "sensor_msgs/msg/joint_state.hpp"
-
+#include "pendulum2_msgs/msg/joint_state.hpp"
 #include "pendulum2_msgs/msg/joint_command_stamped.hpp"
 #include "pendulum2_msgs/msg/pendulum_teleop.hpp"
 #include "pendulum_controller/visibility_control.hpp"

--- a/pendulum_controller/include/pendulum_controller/pendulum_controller.hpp
+++ b/pendulum_controller/include/pendulum_controller/pendulum_controller.hpp
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "pendulum2_msgs/msg/joint_state.hpp"
-#include "pendulum2_msgs/msg/joint_command_stamped.hpp"
+#include "pendulum2_msgs/msg/joint_command.hpp"
 #include "pendulum2_msgs/msg/pendulum_teleop.hpp"
 #include "pendulum_controller/visibility_control.hpp"
 

--- a/pendulum_controller/include/pendulum_controller/pendulum_controller_node.hpp
+++ b/pendulum_controller/include/pendulum_controller/pendulum_controller_node.hpp
@@ -100,13 +100,11 @@ private:
 
   PendulumController controller_;
 
-  std::shared_ptr<rclcpp::Subscription<
-      sensor_msgs::msg::JointState>> state_sub_;
-  std::shared_ptr<rclcpp::Subscription<
-      pendulum2_msgs::msg::PendulumTeleop>> teleop_sub_;
+  std::shared_ptr<rclcpp::Subscription<pendulum2_msgs::msg::JointState>> state_sub_;
+  std::shared_ptr<rclcpp::Subscription<pendulum2_msgs::msg::PendulumTeleop>> teleop_sub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<
-      pendulum2_msgs::msg::JointCommandStamped>> command_pub_;
-  pendulum2_msgs::msg::JointCommandStamped command_message_;
+      pendulum2_msgs::msg::JointCommand>> command_pub_;
+  pendulum2_msgs::msg::JointCommand command_message_;
 
   uint32_t num_missed_deadlines_pub_;
   uint32_t num_missed_deadlines_sub_;

--- a/pendulum_controller/params/test.param.yaml
+++ b/pendulum_controller/params/test.param.yaml
@@ -1,6 +1,6 @@
 pendulum_controller:
   ros__parameters:
-    state_topic_name: "joint_states"
+    state_topic_name: "pendulum_joint_states"
     command_topic_name: "joint_command"
     teleop_topic_name: "teleop"
     enable_topic_stats: False

--- a/pendulum_controller/src/pendulum_controller_node.cpp
+++ b/pendulum_controller/src/pendulum_controller_node.cpp
@@ -71,21 +71,20 @@ void PendulumControllerNode::create_state_subscription()
     state_subscription_options.topic_stats_options.publish_topic = topic_stats_topic_name_;
     state_subscription_options.topic_stats_options.publish_period = topic_stats_publish_period_;
   }
-  auto on_sensor_message = [this](const sensor_msgs::msg::JointState::SharedPtr msg) {
+  auto on_sensor_message = [this](const pendulum2_msgs::msg::JointState::SharedPtr msg) {
       // update pendulum state
       controller_.set_state(
-        msg->position[0], msg->velocity[0],
-        msg->position[1], msg->velocity[1]);
+        msg->cart_position, msg->cart_velocity,
+        msg->pole_angle, msg->pole_velocity);
 
       // update pendulum controller output
       controller_.update();
 
       // publish pendulum force command
-      command_message_.cmd.force = controller_.get_force_command();
-      command_message_.header.stamp = this->get_clock()->now();
+      command_message_.force = controller_.get_force_command();
       command_pub_->publish(command_message_);
     };
-  state_sub_ = this->create_subscription<sensor_msgs::msg::JointState>(
+  state_sub_ = this->create_subscription<pendulum2_msgs::msg::JointState>(
     state_topic_name_,
     rclcpp::QoS(10).deadline(deadline_duration_),
     on_sensor_message,
@@ -100,7 +99,7 @@ void PendulumControllerNode::create_command_publisher()
     {
       num_missed_deadlines_pub_++;
     };
-  command_pub_ = this->create_publisher<pendulum2_msgs::msg::JointCommandStamped>(
+  command_pub_ = this->create_publisher<pendulum2_msgs::msg::JointCommand>(
     command_topic_name_,
     rclcpp::QoS(10).deadline(deadline_duration_),
     command_publisher_options);

--- a/pendulum_controller/test/test_pendulum_controller_node.cpp
+++ b/pendulum_controller/test/test_pendulum_controller_node.cpp
@@ -89,3 +89,13 @@ TEST_F(TestPendulumControllerNode, trigger_lifecycle_transitions) {
     State::PRIMARY_STATE_FINALIZED, controller_node.trigger_transition(
       rclcpp_lifecycle::Transition(Transition::TRANSITION_UNCONFIGURED_SHUTDOWN)).id());
 }
+
+TEST_F(TestPendulumControllerNode, pendulum_state_message_size) {
+  EXPECT_TRUE(rosidl_generator_traits::has_bounded_size<pendulum2_msgs::msg::JointState>());
+  EXPECT_TRUE(rosidl_generator_traits::has_fixed_size<pendulum2_msgs::msg::JointState>());
+}
+
+TEST_F(TestPendulumControllerNode, pendulum_command_message_size) {
+  EXPECT_TRUE(rosidl_generator_traits::has_bounded_size<pendulum2_msgs::msg::JointCommand>());
+  EXPECT_TRUE(rosidl_generator_traits::has_fixed_size<pendulum2_msgs::msg::JointCommand>());
+}

--- a/pendulum_demo/params/test.param.yaml
+++ b/pendulum_demo/params/test.param.yaml
@@ -1,6 +1,6 @@
 pendulum_controller:
   ros__parameters:
-    state_topic_name: "joint_states"
+    state_topic_name: "pendulum_joint_states"
     command_topic_name: "joint_command"
     teleop_topic_name: "teleop"
     enable_topic_stats: False
@@ -12,7 +12,7 @@ pendulum_controller:
 
 pendulum_driver:
   ros__parameters:
-    state_topic_name: "joint_states"
+    state_topic_name: "pendulum_joint_states"
     command_topic_name: "joint_command"
     disturbance_topic_name: "disturbance"
     cart_base_joint_name: "cart_base_joint"

--- a/pendulum_driver/include/pendulum_driver/pendulum_driver.hpp
+++ b/pendulum_driver/include/pendulum_driver/pendulum_driver.hpp
@@ -24,7 +24,7 @@
 #include <random>
 
 #include "pendulum2_msgs/msg/joint_state.hpp"
-#include "pendulum2_msgs/msg/joint_command_stamped.hpp"
+#include "pendulum2_msgs/msg/joint_command.hpp"
 
 #include "pendulum_driver/runge_kutta.hpp"
 #include "pendulum_driver/visibility_control.hpp"

--- a/pendulum_driver/include/pendulum_driver/pendulum_driver.hpp
+++ b/pendulum_driver/include/pendulum_driver/pendulum_driver.hpp
@@ -23,7 +23,7 @@
 #include <vector>
 #include <random>
 
-#include "sensor_msgs/msg/joint_state.hpp"
+#include "pendulum2_msgs/msg/joint_state.hpp"
 #include "pendulum2_msgs/msg/joint_command_stamped.hpp"
 
 #include "pendulum_driver/runge_kutta.hpp"

--- a/pendulum_driver/include/pendulum_driver/pendulum_driver_node.hpp
+++ b/pendulum_driver/include/pendulum_driver/pendulum_driver_node.hpp
@@ -107,16 +107,13 @@ private:
   std::chrono::milliseconds deadline_duration_;
   PendulumDriver driver_;
 
-  std::shared_ptr<rclcpp::Subscription<
-      pendulum2_msgs::msg::JointCommandStamped>> command_sub_;
-  std::shared_ptr<rclcpp::Subscription<
-      pendulum2_msgs::msg::JointCommandStamped>> disturbance_sub_;
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<
-      sensor_msgs::msg::JointState>> state_pub_;
+  std::shared_ptr<rclcpp::Subscription<pendulum2_msgs::msg::JointCommand>> command_sub_;
+  std::shared_ptr<rclcpp::Subscription<pendulum2_msgs::msg::JointCommand>> disturbance_sub_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<pendulum2_msgs::msg::JointState>> state_pub_;
 
   rclcpp::TimerBase::SharedPtr state_timer_;
   rclcpp::TimerBase::SharedPtr update_driver_timer_;
-  sensor_msgs::msg::JointState state_message_;
+  pendulum2_msgs::msg::JointState state_message_;
 
   uint32_t num_missed_deadlines_pub_;
   uint32_t num_missed_deadlines_sub_;

--- a/pendulum_driver/params/test.param.yaml
+++ b/pendulum_driver/params/test.param.yaml
@@ -1,6 +1,6 @@
 pendulum_driver:
   ros__parameters:
-    state_topic_name: "joint_states"
+    state_topic_name: "pendulum_joint_states"
     command_topic_name: "joint_command"
     disturbance_topic_name: "disturbance"
     cart_base_joint_name: "cart_base_joint"

--- a/pendulum_driver/test/test_pendulum_driver_node.cpp
+++ b/pendulum_driver/test/test_pendulum_driver_node.cpp
@@ -96,3 +96,13 @@ TEST_F(TestPendulumDriverNode, trigger_lifecycle_transitions) {
     State::PRIMARY_STATE_FINALIZED, driver_node.trigger_transition(
       rclcpp_lifecycle::Transition(Transition::TRANSITION_UNCONFIGURED_SHUTDOWN)).id());
 }
+
+TEST_F(TestPendulumDriverNode, pendulum_state_message_size) {
+  EXPECT_TRUE(rosidl_generator_traits::has_bounded_size<pendulum2_msgs::msg::JointState>());
+  EXPECT_TRUE(rosidl_generator_traits::has_fixed_size<pendulum2_msgs::msg::JointState>());
+}
+
+TEST_F(TestPendulumDriverNode, pendulum_command_message_size) {
+  EXPECT_TRUE(rosidl_generator_traits::has_bounded_size<pendulum2_msgs::msg::JointCommand>());
+  EXPECT_TRUE(rosidl_generator_traits::has_fixed_size<pendulum2_msgs::msg::JointCommand>());
+}

--- a/pendulum_state_publisher/CMakeLists.txt
+++ b/pendulum_state_publisher/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.5)
+project(pendulum_state_publisher)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(pendulum2_msgs REQUIRED)
+
+add_executable(pendulum_state_publisher pendulum_state_publisher.cpp)
+ament_target_dependencies(pendulum_state_publisher rclcpp pendulum2_msgs sensor_msgs)
+
+install(TARGETS
+  pendulum_state_publisher
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/pendulum_state_publisher/package.xml
+++ b/pendulum_state_publisher/package.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
-  <name>pendulum_bringup</name>
+  <name>pendulum_state_publisher</name>
   <version>0.0.1</version>
-  <description> pendulum bringup </description>
+  <description>Re-publish pendulum2_msgs JoinStates to sensor_msgs JoinStates</description>
   <maintainer email="carlos.svic@gmail.com">Carlos San Vicente</maintainer>
   <license>Apache License 2.0</license>
+  <author>Carlos San Vicente</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>launch_ros</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>pendulum2_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
 
-  <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rviz2</exec_depend>
-  <exec_depend>pendulum_demo</exec_depend>
-  <exec_depend>pendulum_state_publisher</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>pendulum2_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/pendulum_state_publisher/pendulum_state_publisher.cpp
+++ b/pendulum_state_publisher/pendulum_state_publisher.cpp
@@ -1,0 +1,65 @@
+// Copyright 2021 Carlos San Vicente
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
+#include "pendulum2_msgs/msg/joint_state.hpp"
+
+
+class PendulumStatePublisher : public rclcpp::Node
+{
+public:
+  PendulumStatePublisher()
+  : Node("pendulum_state_publisher")
+  {
+    state_message_.name.push_back("cart_base_joint");
+    state_message_.position.push_back(0.0);
+    state_message_.velocity.push_back(0.0);
+    state_message_.effort.push_back(0.0);
+    state_message_.name.push_back("pole_joint");
+    state_message_.position.push_back(0.0);
+    state_message_.velocity.push_back(0.0);
+    state_message_.effort.push_back(0.0);
+
+    publisher_ = this->create_publisher<sensor_msgs::msg::JointState>("joint_states", 10);
+
+    subscription_ = this->create_subscription<pendulum2_msgs::msg::JointState>(
+      "pendulum_joint_states",
+      10,
+      [this](pendulum2_msgs::msg::JointState::UniquePtr msg) {
+        state_message_.position[0] = msg->cart_position;
+        state_message_.velocity[0] = msg->cart_velocity;
+        state_message_.effort[0] = msg->cart_force;
+        state_message_.position[1] = msg->pole_angle;
+        state_message_.velocity[1] = msg->pole_velocity;
+        state_message_.header.stamp = this->get_clock()->now();
+        this->publisher_->publish(state_message_);
+      });
+  }
+
+private:
+  sensor_msgs::msg::JointState state_message_;
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr publisher_;
+  rclcpp::Subscription<pendulum2_msgs::msg::JointState>::SharedPtr subscription_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<PendulumStatePublisher>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
This PR:
-  replaces the used messages with fixed-size message types
- Adds a node to republish the fixed size to a sensor::msgs::JointState message to be compatible with robot_state_publisher and rviz

This is part of a set of PRs to remove dynamic memory allocation for the message types.