### PR TITLE
WIP: Use rttexecutor to run the demo

### DIFF
--- a/pendulum_bringup/launch/pendulum_bringup.launch.py
+++ b/pendulum_bringup/launch/pendulum_bringup.launch.py
@@ -65,6 +65,26 @@ def generate_launch_description():
         name='config-child-threads',
         default_value='False',
         description='Configure process child threads (typically DDS threads)')
+    lock_memory_size_param = DeclareLaunchArgument(
+        name='lock-memory-size',
+        default_value='0',
+        description='Set lock memory size in MB')
+    use_rtt_executor = DeclareLaunchArgument(
+        name='use-rtt-executor',
+        default_value='False',
+        description='Use real-time executor using rttest')
+    filename = DeclareLaunchArgument(
+        name='filename',
+        default_value='results',
+        description='Set rttest results filename')
+    iterations = DeclareLaunchArgument(
+        name='iterations',
+        default_value='1000',
+        description='Set demo number of iterations')
+    update_period = DeclareLaunchArgument(
+        name='update-period',
+        default_value='10000',
+        description='Set executor update period')
     with_rviz_param = DeclareLaunchArgument(
         'rviz',
         default_value='False',
@@ -83,7 +103,11 @@ def generate_launch_description():
            '--cpu-affinity', LaunchConfiguration('cpu-affinity'),
            '--lock-memory', LaunchConfiguration('lock-memory'),
            '--lock-memory-size', LaunchConfiguration('lock-memory-size'),
-           '--config-child-threads', LaunchConfiguration('config-child-threads')
+           '--config-child-threads', LaunchConfiguration('config-child-threads'),
+           '--use-rtt-executor', LaunchConfiguration('use-rtt-executor'),
+           '--iterations', LaunchConfiguration('iterations'),
+           '--filename', LaunchConfiguration('filename'),
+           '--update-period', LaunchConfiguration('update-period')
            ]
     )
 
@@ -117,6 +141,10 @@ def generate_launch_description():
     ld.add_action(with_lock_memory_param)
     ld.add_action(lock_memory_size_param)
     ld.add_action(config_child_threads_param)
+    ld.add_action(use_rtt_executor)
+    ld.add_action(filename)
+    ld.add_action(iterations)
+    ld.add_action(update_period)
     ld.add_action(with_rviz_param)
     ld.add_action(robot_state_publisher_runner)
     ld.add_action(pendulum_demo_runner)

--- a/pendulum_controller/src/pendulum_controller_node_main.cpp
+++ b/pendulum_controller/src/pendulum_controller_node_main.cpp
@@ -20,6 +20,8 @@
 #include "pendulum_controller/pendulum_controller_node.hpp"
 #include "pendulum_utils/process_settings.hpp"
 #include "pendulum_utils/lifecycle_autostart.hpp"
+#include "pendulum_utils/rtt_executor.hpp"
+
 
 int main(int argc, char * argv[])
 {
@@ -37,8 +39,8 @@ int main(int argc, char * argv[])
     }
     rclcpp::init(argc, argv);
 
-    // Create a static executor
-    rclcpp::executors::StaticSingleThreadedExecutor exec;
+    // Create real-time instrumented executor
+    pendulum::utils::RttExecutor exec;
 
     // Create pendulum controller node
     using pendulum::pendulum_controller::PendulumControllerNode;

--- a/pendulum_demo/src/pendulum_demo.cpp
+++ b/pendulum_demo/src/pendulum_demo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Carlos San Vicente
+// Copyright 2021 Carlos San Vicente
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include "pendulum_controller/pendulum_controller_node.hpp"
 #include "pendulum_utils/process_settings.hpp"
 #include "pendulum_utils/lifecycle_autostart.hpp"
+#include "pendulum_utils/rtt_executor.hpp"
 
 int main(int argc, char * argv[])
 {
@@ -41,21 +42,27 @@ int main(int argc, char * argv[])
 
     rclcpp::init(argc, argv);
 
-    // Create a static executor
-    rclcpp::executors::StaticSingleThreadedExecutor exec;
+    std::unique_ptr<rclcpp::Executor> exec;
+
+    if (settings.use_rtt_executor) {
+      // Create real-time instrumented executor
+      exec = std::make_unique<pendulum::utils::RttExecutor>();
+    } else {
+      exec = std::make_unique<rclcpp::executors::StaticSingleThreadedExecutor>();
+    }
 
     // Create pendulum controller node
     using pendulum::pendulum_controller::PendulumControllerNode;
     const auto controller_node_ptr =
-      std::make_shared<PendulumControllerNode>("pendulum_controller");
+        std::make_shared<PendulumControllerNode>("pendulum_controller");
 
-    exec.add_node(controller_node_ptr->get_node_base_interface());
+    exec->add_node(controller_node_ptr->get_node_base_interface());
 
     // Create pendulum simulation
     using pendulum::pendulum_driver::PendulumDriverNode;
     const auto driver_node_ptr = std::make_shared<PendulumDriverNode>("pendulum_driver");
 
-    exec.add_node(driver_node_ptr->get_node_base_interface());
+    exec->add_node(driver_node_ptr->get_node_base_interface());
 
     // configure process real-time settings
     if (!settings.configure_child_threads) {
@@ -68,15 +75,15 @@ int main(int argc, char * argv[])
       pendulum::utils::autostart(*driver_node_ptr);
     }
 
-    exec.spin();
+    exec->spin();
     rclcpp::shutdown();
   } catch (const std::exception & e) {
     RCLCPP_INFO(rclcpp::get_logger("pendulum_demo"), e.what());
     ret = 2;
   } catch (...) {
     RCLCPP_INFO(
-      rclcpp::get_logger("pendulum_demo"), "Unknown exception caught. "
-      "Exiting...");
+        rclcpp::get_logger("pendulum_demo"), "Unknown exception caught. "
+                                             "Exiting...");
     ret = -1;
   }
   return ret;

--- a/pendulum_demo/src/pendulum_demo.cpp
+++ b/pendulum_demo/src/pendulum_demo.cpp
@@ -54,7 +54,7 @@ int main(int argc, char * argv[])
     // Create pendulum controller node
     using pendulum::pendulum_controller::PendulumControllerNode;
     const auto controller_node_ptr =
-        std::make_shared<PendulumControllerNode>("pendulum_controller");
+      std::make_shared<PendulumControllerNode>("pendulum_controller");
 
     exec->add_node(controller_node_ptr->get_node_base_interface());
 
@@ -82,8 +82,8 @@ int main(int argc, char * argv[])
     ret = 2;
   } catch (...) {
     RCLCPP_INFO(
-        rclcpp::get_logger("pendulum_demo"), "Unknown exception caught. "
-                                             "Exiting...");
+      rclcpp::get_logger("pendulum_demo"), "Unknown exception caught. "
+      "Exiting...");
     ret = -1;
   }
   return ret;

--- a/pendulum_driver/src/pendulum_driver_node_main.cpp
+++ b/pendulum_driver/src/pendulum_driver_node_main.cpp
@@ -20,6 +20,8 @@
 #include "pendulum_driver/pendulum_driver_node.hpp"
 #include "pendulum_utils/process_settings.hpp"
 #include "pendulum_utils/lifecycle_autostart.hpp"
+#include "pendulum_utils/rtt_executor.hpp"
+
 
 int main(int argc, char * argv[])
 {
@@ -37,8 +39,8 @@ int main(int argc, char * argv[])
     }
     rclcpp::init(argc, argv);
 
-    // Create a static executor
-    rclcpp::executors::StaticSingleThreadedExecutor exec;
+    // Create real-time instrumented executor
+    pendulum::utils::RttExecutor exec;
 
     // Create pendulum simulation
     using pendulum::pendulum_driver::PendulumDriverNode;

--- a/pendulum_utils/CMakeLists.txt
+++ b/pendulum_utils/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
+find_package(rttest REQUIRED)
 
 set(PENDULUM_UTILS_LIB pendulum_utils)
 
@@ -29,13 +30,14 @@ target_include_directories(${PENDULUM_UTILS_LIB}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
-ament_target_dependencies(${PENDULUM_UTILS_LIB} "rclcpp")
+ament_target_dependencies(${PENDULUM_UTILS_LIB} "rclcpp" "rttest")
 
 ament_export_targets(export_${PENDULUM_UTILS_LIB} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
     "rclcpp"
     "rclcpp_lifecycle"
     "lifecycle_msgs"
+    "rttest"
 )
 
 if(BUILD_TESTING)

--- a/pendulum_utils/include/pendulum_utils/process_settings.hpp
+++ b/pendulum_utils/include/pendulum_utils/process_settings.hpp
@@ -100,7 +100,7 @@ struct ProcessSettings
     // rttest args
     if (rcutils_cli_option_exist(argv, argv + argc, OPTION_USE_RTT_EXECUTOR.c_str())) {
       std::string option = rcutils_cli_get_option(
-          argv, argv + argc, OPTION_USE_RTT_EXECUTOR.c_str());
+        argv, argv + argc, OPTION_USE_RTT_EXECUTOR.c_str());
       use_rtt_executor = (option == "True");
     }
     if (rcutils_cli_option_exist(argv, argv + argc, OPTION_ITERATIONS.c_str())) {
@@ -164,7 +164,7 @@ struct ProcessSettings
   const std::string OPTION_USE_RTT_EXECUTOR = "--use-rtt-executor";
   const std::string OPTION_ITERATIONS = "--iterations";
   const std::string OPTION_UPDATE_PERIOD_US = "--update-period";
-  const std::string OPTION_FILENAME= "--filename";
+  const std::string OPTION_FILENAME = "--filename";
 
   /// automatically activate lifecycle nodes
   bool auto_start_nodes = false;

--- a/pendulum_utils/include/pendulum_utils/rtt_executor.hpp
+++ b/pendulum_utils/include/pendulum_utils/rtt_executor.hpp
@@ -1,0 +1,128 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code adapted from:
+// https://github.com/ros2/demos/blob/master/pendulum_control/include/pendulum_control/rtt_executor.hpp
+
+#ifndef PENDULUM_UTILS__RTT_EXECUTOR_HPP_
+#define PENDULUM_UTILS__RTT_EXECUTOR_HPP_
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "rttest/rttest.h"
+#include "rttest/utils.h"
+
+#include "rmw/rmw.h"
+
+#include "rclcpp/executor.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/memory_strategies.hpp"
+
+namespace pendulum
+{
+namespace utils
+{
+/// Instrumented executor that syncs Executor::spin functions with rttest_spin.
+class RttExecutor : public rclcpp::Executor
+{
+public:
+  /// Constructor
+  /**
+   * Extends default Executor constructor
+   */
+  RttExecutor(
+    const rclcpp::ExecutorOptions & options = rclcpp::ExecutorOptions())
+  : rclcpp::Executor(options), running(false)
+  {
+    rttest_ready = rttest_running();
+    memset(&start_time_, 0, sizeof(timespec));
+  }
+
+  /// Default destructor
+  virtual ~RttExecutor() {}
+
+  /// Return true if the executor is currently spinning.
+  // \return True if rclcpp is running and if the "running" boolean is set to true.
+  bool is_running() const
+  {
+    return rclcpp::ok() && running;
+  }
+
+  /// Wrap executor::spin into rttest_spin.
+  // Do all the work available to the executor for as many iterations specified by rttest.
+  void spin()
+  {
+    // This call will block until rttest is finished, calling loop_callback at periodic intervals
+    // specified on the command line.
+    rttest_spin(RttExecutor::loop_callback, static_cast<void *>(this));
+
+    // Clean up state and write results after rttest has finished spinning.
+    running = false;
+    rttest_write_results();
+    if (rttest_running()) {
+      rttest_finish();
+    }
+    rttest_ready = rttest_running();
+  }
+
+  /// Core component of the executor. Do a little bit of work and update extra state.
+  // \param[in] Anonymous argument, will be casted as a pointer to an RttExecutor.
+  static void * loop_callback(void * arg)
+  {
+    // Cast the argument so that we can access the executor's state.
+    RttExecutor * executor = static_cast<RttExecutor *>(arg);
+    // If the input pointer was NULL or invalid, or if rclcpp has stopped, signal rttest to stop.
+    if (!executor || !rclcpp::ok()) {
+      rttest_finish();
+      return 0;
+    }
+    // Single-threaded spin_some: do as much work as we have available.
+    executor->spin_some();
+
+    // Retrieve rttest statistics accumulated so far and store them in the executor.
+    if (rttest_get_statistics(&executor->results) >= 0) {
+      executor->results_available = true;
+    }
+    rttest_get_sample_at(executor->results.iteration, &executor->last_sample);
+    // In case this boolean wasn't set, notify that we've recently run the callback.
+    executor->running = true;
+    return 0;
+  }
+
+  // For storing accumulated performance statistics.
+  rttest_results results;
+  bool results_available{false};
+  // True if the executor is spinning.
+  bool running;
+  // True if rttest has initialized and hasn't been stopped yet.
+  bool rttest_ready;
+
+  int64_t last_sample;
+
+protected:
+  // Absolute timestamp at which the first data point was collected in rttest.
+  timespec start_time_;
+
+private:
+  RCLCPP_DISABLE_COPY(RttExecutor)
+};
+
+}  // namespace utils
+}  // namespace pendulum
+
+#endif  // PENDULUM_UTILS__RTT_EXECUTOR_HPP_

--- a/pendulum_utils/package.xml
+++ b/pendulum_utils/package.xml
@@ -12,6 +12,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>lifecycle_msgs</depend>
+  <depend>rttest</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Instructions:

1. Build demo in a RT target

2. Launch demo with rt settings and rrt executor.

```bash
ros2 run pendulum_demo pendulum_demo --use-rtt-executor True --iterations 1000 --filename demo_rt --autostart True --priority 80 --cpu-affinity:=4 --lock-memory-size 100 --config-child-threads True --ros-args --params-file src/pendulum/pendulum_bringup/params/pendulum.param.yaml 
```

3. We usually get a high latency in the first row. For the moment I edit the file and remove the entry manually.

4. Use script to create plots ( https://github.com/ros2/realtime_support/blob/master/rttest/scripts/rttest_plot )

```bash
 rttest_plot demo_rt
```

5. Open plots and check the results look good

```
rttest statistics for demo:
  - Minor pagefaults: 14
  - Major pagefaults: 0
  Latency (time after deadline was missed):
    - Min: 31266 ns
    - Max: 79539 ns
    - Mean: 62319.022000 ns
    - Standard deviation: 406.922597
```

6. Repeat the experiment stressing the system with and without rt settings.

### To improve

1. Add tests for the rtt executor?
2. Add script to pendulum_analysis?
3. There is duplication in cli arguments and launch arguments


