### PR TITLE
Fix function declaration discrepancy in rt_thread foxy

### DIFF
--- a/pendulum_utils/include/pendulum_utils/rt_thread.hpp
+++ b/pendulum_utils/include/pendulum_utils/rt_thread.hpp
@@ -34,9 +34,9 @@ namespace pendulum
 {
 namespace utils
 {
-int set_thread_priority(size_t sched_priority, int policy);
+int set_thread_priority(pid_t pid, size_t sched_priority, int policy);
 int set_this_thread_priority(size_t sched_priority, int policy);
-int set_thread_cpu_affinity(uint32_t cpu_bit_mask);
+int set_thread_cpu_affinity(pid_t pid, uint32_t cpu_bit_mask);
 int set_this_thread_cpu_affinity(uint32_t cpu_bit_mask);
 }  // namespace utils
 }  // namespace pendulum


### PR DESCRIPTION
Signed-off-by: LanderU <lander.usategui@gmail.com>